### PR TITLE
Replace colon in movie path.

### DIFF
--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -346,7 +346,9 @@ namespace NzbDrone.Core.Organizer
         public static string CleanFolderName(string name)
         {
             name = FileNameCleanupRegex.Replace(name, match => match.Captures[0].Value[0].ToString());
-            return name.Trim(' ', '.');
+            name = name.Trim(' ', '.');
+
+            return name.Replace(":", " -");
         }
 
         private void AddSeriesTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, Series series)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Windows doesn't support `:` in paths.
This changes `Transformers: Age Of Extinction` to `Transformers - Age Of Extinction`.


#### Issues Fixed or Closed by this PR

* https://github.com/galli-leo/Radarr/issues/20
